### PR TITLE
docs: add crypto api documentation

### DIFF
--- a/docs/docs/api/IMPLEMENTATION_STATUS.md
+++ b/docs/docs/api/IMPLEMENTATION_STATUS.md
@@ -10,6 +10,7 @@ This document provides a comprehensive overview of the current implementation st
 |                      | Reverse Geocoding       | ✅ Live        | ✅ Implemented     | ✅ Documented | Fully functional                 |
 |                      | Address Validation      | ⏳ Coming Soon | ❌ Not Implemented | ⏳ Documented | Endpoint exists but throws error |
 |                      | Address Standardization | ⏳ Coming Soon | ❌ Not Implemented | ⏳ Documented | Endpoint exists but throws error |
+| **Crypto**           | Real-time Crypto Prices | ✅ Live        | ✅ Implemented     | ✅ Documented | CoinGecko with cache and fallback |
 | **Exchange Rates**   | Current Rates           | ✅ Live        | ✅ Implemented     | ✅ Documented | Fully functional                 |
 |                      | Currency Conversion     | ✅ Live        | ✅ Implemented     | ✅ Documented | Fully functional                 |
 |                      | Historical Data         | ⏳ Coming Soon | ❌ Not Implemented | ⏳ Documented | Endpoint exists but throws error |
@@ -41,6 +42,17 @@ This document provides a comprehensive overview of the current implementation st
 
 - `GET /exchange-rates/current` - Get current exchange rates
 - `POST /exchange-rates/convert` - Convert currency amounts
+
+### Crypto
+
+#### ✅ Implemented Endpoints
+
+- `GET /crypto` - Get cryptocurrency prices in USD and GHS
+  - Supports comma-separated `ids` query parameter
+  - Uses CoinGecko as the primary upstream provider
+  - Caches responses for 60 seconds
+  - Falls back to simulated pricing data if upstream requests fail
+  - Uses exchange-rates service for USD to GHS conversion
 
 #### ❌ Not Yet Implemented
 
@@ -80,6 +92,7 @@ This document provides a comprehensive overview of the current implementation st
 ### Phase 1: Core Features (✅ Complete)
 
 - Address search and reverse geocoding
+- Crypto price lookup with GHS conversion
 - Current exchange rates and conversion
 - Regional and district data
 
@@ -108,6 +121,7 @@ This document provides a comprehensive overview of the current implementation st
 - All implemented endpoints have unit tests
 - Integration tests for core functionality
 - Error handling tests
+- Crypto controller and service test coverage
 
 ### ⏳ Testing Needed
 

--- a/docs/docs/api/crypto.md
+++ b/docs/docs/api/crypto.md
@@ -1,0 +1,135 @@
+# Crypto API
+
+The Crypto API provides real-time cryptocurrency pricing in both USD and Ghana Cedi (GHS). It uses CoinGecko for live USD pricing, converts values to GHS through the internal exchange-rates service, and falls back to synthetic data when the upstream provider is unavailable or rate-limited.
+
+> **Implementation Status:** ✅ **Fully Implemented** - The endpoint is live and includes caching plus upstream fallback behavior.
+
+## Overview
+
+The API currently exposes a single REST endpoint for fetching crypto prices:
+
+- **Live market pricing** from CoinGecko
+- **Automatic GHS conversion** using the internal exchange-rates module
+- **Short-lived caching** to reduce repeated upstream calls
+- **Fallback response mode** when CoinGecko is unavailable
+
+## Base Endpoint
+
+```text
+https://api.ghana-api.dev/api/v1/crypto
+```
+
+## Available Endpoints
+
+### 1. Get Crypto Prices
+
+Fetch the latest cryptocurrency prices for one or more assets.
+
+**Endpoint:** `GET /crypto`
+
+#### Query Parameters
+
+| Parameter | Type   | Required | Description                                                            | Default                |
+| --------- | ------ | -------- | ---------------------------------------------------------------------- | ---------------------- |
+| `ids`     | string | No       | Comma-separated cryptocurrency IDs such as `bitcoin,ethereum,solana`. | `bitcoin,ethereum` |
+
+#### Example Request
+
+```bash
+curl -X GET "https://api.ghana-api.dev/api/v1/crypto?ids=bitcoin,ethereum,solana" \
+  -H "Accept: application/json"
+```
+
+#### Example Response
+
+```json
+{
+  "source": "coingecko",
+  "data": {
+    "bitcoin": {
+      "usd": 65000,
+      "ghs": 975000
+    },
+    "ethereum": {
+      "usd": 3500,
+      "ghs": 52500
+    },
+    "solana": {
+      "usd": 150,
+      "ghs": 2250
+    }
+  },
+  "timestamp": "2026-03-19T14:36:59.000Z"
+}
+```
+
+#### JavaScript Example
+
+```javascript
+const getCryptoPrices = async (ids = ["bitcoin", "ethereum"]) => {
+  const params = new URLSearchParams({
+    ids: ids.join(","),
+  });
+
+  const response = await fetch(
+    `https://api.ghana-api.dev/api/v1/crypto?${params.toString()}`
+  );
+
+  if (!response.ok) {
+    throw new Error(`API Error: ${response.status}`);
+  }
+
+  return response.json();
+};
+
+const prices = await getCryptoPrices(["bitcoin", "solana"]);
+console.log(prices.data.bitcoin.ghs);
+```
+
+## Response Shape
+
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| `source` | string | `coingecko` when live upstream data succeeds, or `fallback` when simulated backup values are used. |
+| `data` | object | Keyed by crypto ID. Each item includes `usd` and `ghs` values. |
+| `timestamp` | string | ISO 8601 timestamp indicating when the response object was created. |
+
+## Caching Behavior
+
+- Responses are cached for **60 seconds**
+- Cache keys are built from the requested IDs after sorting them alphabetically
+- Repeated requests for the same ID set within the cache window return the cached payload
+
+Example cache key:
+
+```text
+crypto:prices:bitcoin,ethereum,solana
+```
+
+## Fallback Behavior
+
+If CoinGecko fails or rate-limits the request, the service automatically switches to fallback mode:
+
+- The response `source` becomes `fallback`
+- USD values are populated from an internal fallback store
+- Supported fallback presets currently include:
+  - `bitcoin`
+  - `ethereum`
+  - `solana`
+  - `cardano`
+  - `binancecoin`
+  - `ripple`
+- Unknown IDs in fallback mode receive a default synthetic USD value of `100`
+
+### GHS Conversion Fallback
+
+After USD prices are fetched, the service converts each amount to GHS through the exchange-rates module. If that conversion fails:
+
+- The service logs a warning
+- GHS is approximated with a fallback multiplier of `15.0`
+
+## Notes and Limitations
+
+- The endpoint currently accepts only a comma-separated `ids` query string
+- Returned objects include only assets that resolve to a USD price during processing
+- Fallback values are intended for resilience and continuity, not precise trading or treasury use

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -15,6 +15,7 @@ const sidebars: SidebarsConfig = {
         "api/overview",
         "api/addresses",
         "api/banking",
+        "api/crypto",
         "api/education",
         "api/exchange-rates",
         "api/locations",

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -23,9 +23,9 @@ function HomepageHeader() {
             <p className={styles.heroSubtitle}>
               The definitive REST API for Ghanaian services. Access
               comprehensive data for education, addresses, banking facilities,
-              exchange rates, stock market information, transport & logistics,
-              and administrative insights with our reliable, developer-friendly
-              platform.
+              exchange rates, crypto prices, stock market information,
+              transport & logistics, and administrative insights with our
+              reliable, developer-friendly platform.
             </p>
             <div className={styles.heroStats}>
               <div className={styles.stat}>
@@ -33,7 +33,7 @@ function HomepageHeader() {
                 <span className={styles.statLabel}>API Endpoints</span>
               </div>
               <div className={styles.stat}>
-                <span className={styles.statNumber}>7</span>
+                <span className={styles.statNumber}>8</span>
                 <span className={styles.statLabel}>Core Services</span>
               </div>
               <div className={styles.stat}>
@@ -117,6 +117,11 @@ const location = await fetch(
 // Currency conversion
 const conversion = await fetch(
   'https://api.ghana-api.dev/api/v1/exchange-rates/convert?from=USD&to=GHS&amount=100'
+);
+
+// Get crypto prices
+const crypto = await fetch(
+  'https://api.ghana-api.dev/api/v1/crypto?ids=bitcoin,ethereum'
 );`}</code>
               </pre>
             </div>
@@ -169,6 +174,17 @@ function FeaturesSection() {
               providers
             </p>
             <Link to="/docs/api/exchange-rates" className={styles.featureLink}>
+              Learn More →
+            </Link>
+          </div>
+          <div className={styles.featureCard}>
+            <div className={styles.featureIcon}>₿</div>
+            <h3>Crypto Prices</h3>
+            <p>
+              Live cryptocurrency pricing in USD and GHS with CoinGecko-backed
+              data, short-term caching, and fallback support
+            </p>
+            <Link to="/docs/api/crypto" className={styles.featureLink}>
               Learn More →
             </Link>
           </div>


### PR DESCRIPTION
## Summary

Adds documentation for the Crypto module and exposes it across the Docusaurus site.

## Changes

- add a new API doc page for GET /crypto
- document query params, response shape, caching, and fallback behavior
- update implementation status to include the Crypto service
- add Crypto to the docs sidebar navigation
- add Crypto to the docs homepage service cards
- update the homepage hero copy and service count from 7 to 8

## Verification

- ran npm run build in docs
- confirmed Docusaurus builds successfully with the new page and homepage updates

## Related

Closes #32